### PR TITLE
Fix modbus return logic to handle temporary failures

### DIFF
--- a/custom_components/abb_powerone_pvi_sunspec/__init__.py
+++ b/custom_components/abb_powerone_pvi_sunspec/__init__.py
@@ -193,7 +193,7 @@ class ABBPowerOnePVISunSpecHub:
             return self.read_modbus_data_inverter() and self.read_modbus_data_realtime()
         except ConnectionException as ex:
             _LOGGER.error("Reading data failed! Inverter is unreachable on ID=%s", self._slave_id)
-            return True
+            return False
 
     def read_modbus_data_inverter_stub(self):
         self.data["comm_manufact"] = ""


### PR DESCRIPTION
This fixes inverters that will fail in the early morning and causes the Home Assistant Entity to go unavailable. We should be returning False here if the inverter is unreachable.