### PR TITLE
update multi mppt changes to current v3.1.5

### DIFF
--- a/custom_components/abb_powerone_pvi_sunspec/api.py
+++ b/custom_components/abb_powerone_pvi_sunspec/api.py
@@ -158,6 +158,7 @@ class ABBPowerOnePVISunSpecHub:
         self.data["comm_model"] = ""
         self.data["comm_version"] = ""
         self.data["comm_sernum"] = ""
+        self.data["mppt_nr"] = 1
         self.data["dccurr"] = 1
         self.data["dcvolt"] = 1
         self.data["dcpower"] = 1
@@ -472,6 +473,8 @@ class ABBPowerOnePVISunSpecHub:
 
         # register 130 (# of DC modules)
         multi_mppt_nr = decoder.decode_16bit_int()
+        self.data["mppt_nr"] = multi_mppt_nr
+        _LOGGER.debug("(read_rt_160) mppt_nr %d", multi_mppt_nr)
 
         if multi_mppt_id == 160:
 

--- a/custom_components/abb_powerone_pvi_sunspec/const.py
+++ b/custom_components/abb_powerone_pvi_sunspec/const.py
@@ -61,9 +61,6 @@ SENSOR_TYPES_SINGLE_PHASE = {
     "AC_Power": ["AC Power", "acpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
     "AC_Frequency": ["AC Frequency", "acfreq", UnitOfFrequency.HERTZ, "mdi:sine-wave", None, STATE_CLASS_MEASUREMENT],
     "Total_Energy": ["Total Energy", "totalenergy", UnitOfEnergy.WATT_HOUR, "mdi:solar-power", SensorDeviceClass.ENERGY, STATE_CLASS_TOTAL_INCREASING],
-    "DC_Curr": ["DC Current", "dccurr", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
-    "DC_Volt": ["DC Voltage", "dcvolt", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
-    "DC_Power": ["DC Power", "dcpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
     "Status": ["Operating State", "status", None, "mdi:information-outline", None, None],
     "Status_Vendor": ["Vendor Operating State", "statusvendor", None, "mdi:information-outline", None, None],
     "Temp_Cab": ["Ambient Temperature", "tempcab", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
@@ -90,6 +87,20 @@ SENSOR_TYPES_THREE_PHASE = {
     "AC_Power": ["AC Power", "acpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
     "AC_Frequency": ["AC Frequency", "acfreq", UnitOfFrequency.HERTZ, "mdi:sine-wave", None, STATE_CLASS_MEASUREMENT],
     "Total_Energy": ["Total Energy", "totalenergy", UnitOfEnergy.WATT_HOUR, "mdi:solar-power", SensorDeviceClass.ENERGY, STATE_CLASS_TOTAL_INCREASING],
+    "Status": ["Operating State", "status", None, "mdi:information-outline", None, None],
+    "Status_Vendor": ["Vendor Operating State", "statusvendor", None, "mdi:information-outline", None, None],
+    "Temp_Cab": ["Ambient Temperature", "tempcab", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
+    "Temp_Oth": ["Inverter Temperature", "tempoth", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
+}
+
+
+SENSOR_TYPES_SINGLE_MPPT = {
+    "DC_Curr": ["DC Current", "dccurr", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
+    "DC_Volt": ["DC Voltage", "dcvolt", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
+    "DC_Power": ["DC Power", "dcpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
+}
+
+SENSOR_TYPES_MULTIPLE_MPPT = {
     "DC_Power": ["DC Power", "dcpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
     "DC1_Curr": ["DC1 Current", "dc1curr", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
     "DC1_Volt": ["DC1 Voltage", "dc1volt", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
@@ -97,10 +108,6 @@ SENSOR_TYPES_THREE_PHASE = {
     "DC2_Curr": ["DC2 Current", "dc2curr", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
     "DC2_Volt": ["DC2 Voltage", "dc2volt", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
     "DC2_Power": ["DC2 Power", "dc2power", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
-    "Status": ["Operating State", "status", None, "mdi:information-outline", None, None],
-    "Status_Vendor": ["Vendor Operating State", "statusvendor", None, "mdi:information-outline", None, None],
-    "Temp_Cab": ["Ambient Temperature", "tempcab", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
-    "Temp_Oth": ["Inverter Temperature", "tempoth", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
 }
 
 INVERTER_TYPE = {

--- a/custom_components/abb_powerone_pvi_sunspec/const.py
+++ b/custom_components/abb_powerone_pvi_sunspec/const.py
@@ -49,7 +49,8 @@ If you have any issues with this you need to open an issue here:
 -------------------------------------------------------------------
 """
 
-SENSOR_TYPES_SINGLE_PHASE = {
+# Sensors for all inverters
+SENSOR_TYPES_COMMON = {
     "Manufacturer": ["Manufacturer", "comm_manufact", None, "mdi:information-outline", None, None],
     "Model": ["Model", "comm_model", None, "mdi:information-outline", None, None],
     "Options": ["Options", "comm_options", None, "mdi:information-outline", None, None],
@@ -60,48 +61,40 @@ SENSOR_TYPES_SINGLE_PHASE = {
     "AC_VoltageAN": ["AC Voltage AN", "acvoltagean", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
     "AC_Power": ["AC Power", "acpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
     "AC_Frequency": ["AC Frequency", "acfreq", UnitOfFrequency.HERTZ, "mdi:sine-wave", None, STATE_CLASS_MEASUREMENT],
+    "DC_Power": ["DC Power", "dcpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
     "Total_Energy": ["Total Energy", "totalenergy", UnitOfEnergy.WATT_HOUR, "mdi:solar-power", SensorDeviceClass.ENERGY, STATE_CLASS_TOTAL_INCREASING],
     "Status": ["Operating State", "status", None, "mdi:information-outline", None, None],
     "Status_Vendor": ["Vendor Operating State", "statusvendor", None, "mdi:information-outline", None, None],
     "Temp_Cab": ["Ambient Temperature", "tempcab", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
     "Temp_Oth": ["Inverter Temperature", "tempoth", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
+    "MPPT_Count": ["MPPT Count", "mppt_nr", None, "mdi:information-outline", None, None],
 }
 
+# Sensors for single phase inverters, apparently does not have any specific sensors
+SENSOR_TYPES_SINGLE_PHASE = {
+}
+
+# Sensors for three phase inverters
 SENSOR_TYPES_THREE_PHASE = {
-    "Manufacturer": ["Manufacturer", "comm_manufact", None, "mdi:information-outline", None, None],
-    "Model": ["Model", "comm_model", None, "mdi:information-outline", None, None],
-    "Options": ["Options", "comm_options", None, "mdi:information-outline", None, None],
-    "Version": ["Firmware Version", "comm_version", None, "mdi:information-outline", None, None],
-    "Serial": ["Serial", "comm_sernum", None, "mdi:information-outline", None, None],
-    "Inverter_Type": ["Inverter Type", "invtype", None, "mdi:information-outline", None, None],
-    "AC_Current": ["AC Current", "accurrent", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
     "AC_CurrentA": ["AC Current A", "accurrenta", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
     "AC_CurrentB": ["AC Current B", "accurrentb", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
     "AC_CurrentC": ["AC Current C", "accurrentc", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
     "AC_VoltageAB": ["AC Voltage AB", "acvoltageab", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
     "AC_VoltageBC": ["AC Voltage BC", "acvoltagebc", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
     "AC_VoltageCA": ["AC Voltage CA", "acvoltageca", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
-    "AC_VoltageAN": ["AC Voltage AN", "acvoltagean", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
     "AC_VoltageBN": ["AC Voltage BN", "acvoltagebn", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
     "AC_VoltageCN": ["AC Voltage CN", "acvoltagecn", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
-    "AC_Power": ["AC Power", "acpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
-    "AC_Frequency": ["AC Frequency", "acfreq", UnitOfFrequency.HERTZ, "mdi:sine-wave", None, STATE_CLASS_MEASUREMENT],
-    "Total_Energy": ["Total Energy", "totalenergy", UnitOfEnergy.WATT_HOUR, "mdi:solar-power", SensorDeviceClass.ENERGY, STATE_CLASS_TOTAL_INCREASING],
-    "Status": ["Operating State", "status", None, "mdi:information-outline", None, None],
-    "Status_Vendor": ["Vendor Operating State", "statusvendor", None, "mdi:information-outline", None, None],
-    "Temp_Cab": ["Ambient Temperature", "tempcab", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
-    "Temp_Oth": ["Inverter Temperature", "tempoth", UnitOfTemperature.CELSIUS, "mdi:temperature-celsius", SensorDeviceClass.TEMPERATURE, STATE_CLASS_MEASUREMENT],
 }
 
 
+# Sensors for single mppt inverters
 SENSOR_TYPES_SINGLE_MPPT = {
     "DC_Curr": ["DC Current", "dccurr", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
     "DC_Volt": ["DC Voltage", "dcvolt", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
-    "DC_Power": ["DC Power", "dcpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
 }
 
-SENSOR_TYPES_MULTIPLE_MPPT = {
-    "DC_Power": ["DC Power", "dcpower", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],
+# Sensors for single dual inverters
+SENSOR_TYPES_DUAL_MPPT = {
     "DC1_Curr": ["DC1 Current", "dc1curr", UnitOfElectricCurrent.AMPERE, "mdi:current-ac", SensorDeviceClass.CURRENT, STATE_CLASS_MEASUREMENT],
     "DC1_Volt": ["DC1 Voltage", "dc1volt", UnitOfElectricPotential.VOLT, "mdi:lightning-bolt", SensorDeviceClass.VOLTAGE, STATE_CLASS_MEASUREMENT],
     "DC1_Power": ["DC1 Power", "dc1power", UnitOfPower.WATT, "mdi:solar-power", SensorDeviceClass.POWER, STATE_CLASS_MEASUREMENT],

--- a/custom_components/abb_powerone_pvi_sunspec/sensor.py
+++ b/custom_components/abb_powerone_pvi_sunspec/sensor.py
@@ -8,9 +8,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 
-from .const import (DOMAIN, INVERTER_TYPE, SENSOR_TYPES_SINGLE_PHASE,
+from .const import (DOMAIN, INVERTER_TYPE, 
+                    SENSOR_TYPES_COMMON,
+                    SENSOR_TYPES_SINGLE_PHASE,
                     SENSOR_TYPES_THREE_PHASE,
-                    SENSOR_TYPES_SINGLE_MPPT,SENSOR_TYPES_MULTIPLE_MPPT)
+                    SENSOR_TYPES_SINGLE_MPPT,
+                    SENSOR_TYPES_DUAL_MPPT)
 from .entity import ABBPowerOnePVISunSpecEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -38,19 +41,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_d
     _LOGGER.debug("(sensor) SW Version: %s", hub.data["comm_version"])
     _LOGGER.debug("(sensor) Inverter Type (str): %s", hub.data["invtype"])
     _LOGGER.debug("(sensor) Serial#: %s", hub.data["comm_sernum"])
+
+    add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_COMMON);
+
     if hub.data["invtype"] == INVERTER_TYPE[101]:
         add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_SINGLE_PHASE);
     elif hub.data["invtype"] == INVERTER_TYPE[103]:
         add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_THREE_PHASE)
-    async_add_devices(sensors)
+
     # TODO: check if this check is good for all devices
     # I dont know if all multi mppt will return 0 but on mine this worked fine
     _LOGGER.debug("(sensor) DC Voltages : mppt_nr=%d single=%d dc1=%d dc2=%d", hub.data["mppt_nr"], hub.data["dcvolt"], hub.data["dc1volt"], hub.data["dc2volt"])
     if hub.data["mppt_nr"] == 1:
         add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_SINGLE_MPPT)
     else:
-        add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_MULTIPLE_MPPT)
+        add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_DUAL_MPPT)
         
+    async_add_devices(sensors)
+
     return True
 
 

--- a/custom_components/abb_powerone_pvi_sunspec/sensor.py
+++ b/custom_components/abb_powerone_pvi_sunspec/sensor.py
@@ -9,10 +9,23 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 
 from .const import (DOMAIN, INVERTER_TYPE, SENSOR_TYPES_SINGLE_PHASE,
-                    SENSOR_TYPES_THREE_PHASE)
+                    SENSOR_TYPES_THREE_PHASE,
+                    SENSOR_TYPES_SINGLE_MPPT,SENSOR_TYPES_MULTIPLE_MPPT)
 from .entity import ABBPowerOnePVISunSpecEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+def add_sensor_defs(coordinator, entry, sensors, definitions):
+    for sensor_info in definitions.values():
+        sensor_data = {
+                "name": sensor_info[0],
+                "key": sensor_info[1],
+                "unit": sensor_info[2],
+                "icon": sensor_info[3],
+                "device_class": sensor_info[4],
+                "state_class": sensor_info[5],
+            }        
+        sensors.append(ABBPowerOnePVISunSpecSensor(coordinator, entry, sensor_data))
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_devices):
     """Setup sensor platform"""
@@ -26,28 +39,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_d
     _LOGGER.debug("(sensor) Inverter Type (str): %s", hub.data["invtype"])
     _LOGGER.debug("(sensor) Serial#: %s", hub.data["comm_sernum"])
     if hub.data["invtype"] == INVERTER_TYPE[101]:
-        for sensor_info in SENSOR_TYPES_SINGLE_PHASE.values():
-            sensor_data = {
-                "name": sensor_info[0],
-                "key": sensor_info[1],
-                "unit": sensor_info[2],
-                "icon": sensor_info[3],
-                "device_class": sensor_info[4],
-                "state_class": sensor_info[5],
-            }
-            sensors.append(ABBPowerOnePVISunSpecSensor(coordinator, entry, sensor_data))
+        add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_SINGLE_PHASE);
     elif hub.data["invtype"] == INVERTER_TYPE[103]:
-        for sensor_info in SENSOR_TYPES_THREE_PHASE.values():
-            sensor_data = {
-                "name": sensor_info[0],
-                "key": sensor_info[1],
-                "unit": sensor_info[2],
-                "icon": sensor_info[3],
-                "device_class": sensor_info[4],
-                "state_class": sensor_info[5],
-            }
-            sensors.append(ABBPowerOnePVISunSpecSensor(coordinator, entry, sensor_data))
+        add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_THREE_PHASE)
     async_add_devices(sensors)
+    # TODO: check if this check is good for all devices
+    # I dont know if all multi mppt will return 0 but on mine this worked fine
+    _LOGGER.debug("(sensor) DC Voltages : mppt_nr=%d single=%d dc1=%d dc2=%d", hub.data["mppt_nr"], hub.data["dcvolt"], hub.data["dc1volt"], hub.data["dc2volt"])
+    if hub.data["mppt_nr"] == 1:
+        add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_SINGLE_MPPT)
+    else:
+        add_sensor_defs(coordinator, entry, sensors, SENSOR_TYPES_MULTIPLE_MPPT)
+        
     return True
 
 


### PR DESCRIPTION
This changes are to get multi mppt values from my inverters as reported in #69 .
I have single phase inverters that have dual MPPT, the original code only consider dual MPPT for tri-phase inverters.

I have separated the MPPT definitions from main inverter definitions and added dinamically the definions after getting the mppt_nr parameter.

It is working fine on my devices, but should be tested on a single phase, single mppt to check if my changes work correct in that devices.
I don't know if there are devices with more than 2 MPPT, I just considered this two options as the current code is working for other users.



```
2023-08-10 16:52:05.155 DEBUG (MainThread) [custom_components.abb_powerone_pvi_sunspec] (read_inv) Manufacturer: Power-One
2023-08-10 16:52:05.155 DEBUG (MainThread) [custom_components.abb_powerone_pvi_sunspec] (read_inv) Model: -3G03-
2023-08-10 16:52:05.155 DEBUG (MainThread) [custom_components.abb_powerone_pvi_sunspec] (read_inv) Options: 6
2023-08-10 16:52:05.155 DEBUG (MainThread) [custom_components.abb_powerone_pvi_sunspec] (opt_printable) opt_model: 6 - opt_model_int: 54
2023-08-10 16:52:05.155 DEBUG (MainThread) [custom_components.abb_powerone_pvi_sunspec] (opt_comm_model) comm_model: PVI-6000-OUTD
2023-08-10 16:52:05.155 DEBUG (MainThread) [custom_components.abb_powerone_pvi_sunspec] (read_inv) Version: C033
```

