### PR TITLE
Update api.py (support pymodbus 3.11)

### DIFF
--- a/custom_components/abb_powerone_pvi_sunspec/api.py
+++ b/custom_components/abb_powerone_pvi_sunspec/api.py
@@ -483,7 +483,7 @@ class ABBPowerOneFimerAPI:
         try:
             async with self._lock:
                 result = await self._client.read_holding_registers(
-                    address=address, count=count, slave=self._slave_id
+                    address=address, count=count, device_id=self._slave_id
                 )  # type: ignore (pylance thinks this is not awaitable)
             if result.isError():
                 _LOGGER.debug(f"Modbus error response: {result}")


### PR DESCRIPTION
With the latest Home Assistant update (2025.9.0) the integration is broken because of the update of pymodbus. I updated the file api.py to make it work again. Relates to bug #296 